### PR TITLE
updated get org name partial to use alt title

### DIFF
--- a/layouts/partials/utilities/get-org-name.html
+++ b/layouts/partials/utilities/get-org-name.html
@@ -1,7 +1,7 @@
 {{ $name := slice }}
-{{ if .Site.Data.organization.organization_name }}
-  {{ $name = $name | append .Site.Data.organization.organization_name }}
+{{ if .Site.Params.altTitle }}
+  {{ $name = $name | append .Site.Params.altTitle }}
 {{ else }}
-  {{ $name = $name | append .Site.Title }}
+  {{ $name = $name | append .Site.Title  }}
 {{ end }}
 {{ return index $name 0 }}


### PR DESCRIPTION
* added feature to be able to set an alternate title for use on the front end only. Hugo internal templates will still use the config file's Title parameter.